### PR TITLE
Conform ServiceManager to CitySearching

### DIFF
--- a/CityWeather/CityWeather/UI/Screens/Search/SearchView.swift
+++ b/CityWeather/CityWeather/UI/Screens/Search/SearchView.swift
@@ -9,7 +9,11 @@ import SwiftUI
 import CWModels
 
 struct SearchView: View {
-  @StateObject private var viewModel = SearchViewViewModel()
+  @StateObject private var viewModel: SearchViewViewModel
+
+  init(viewModel: SearchViewViewModel = SearchViewViewModel()) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
   
   var body: some View {
     NavigationStack {

--- a/CityWeather/CityWeather/UI/Screens/Search/SearchViewViewModel.swift
+++ b/CityWeather/CityWeather/UI/Screens/Search/SearchViewViewModel.swift
@@ -9,20 +9,27 @@ import Foundation
 import CWServices
 import CWModels
 
+protocol CitySearching {
+  func getCityByName(cityName: String,
+                     completion: @escaping (_ city: City?, _ error: String?) -> Void)
+}
+
+extension ServiceManager: CitySearching {}
+
 final class SearchViewViewModel: ObservableObject {
-  private var serviceManager = ServiceManager.shared
+  private let citySearcher: CitySearching
   @Published var loadingState: LoadingState = .none
   @Published var history: [City] = []
-  
-  init() {
-    
+
+  init(citySearcher: CitySearching = ServiceManager.shared) {
+    self.citySearcher = citySearcher
   }
-  
+
   func getCityByName(cityName: String) {
     DispatchQueue.main.async {
       self.loadingState = .loading
     }
-    serviceManager.getCityByName(cityName: cityName) { [weak self] city, error in
+    citySearcher.getCityByName(cityName: cityName) { [weak self] city, error in
       DispatchQueue.main.async {
         if let error = error {
           print("Error: \(error)")


### PR DESCRIPTION
## Summary
- make `ServiceManager` conform to the `CitySearching` protocol so its existing `getCityByName` implementation is used directly
- keep `SearchViewViewModel` injectable but default it to `ServiceManager.shared` for production use

## Testing
- not run (not supported in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d6afcbd090832aba4e3fd7ede8bbb0)