### PR TITLE
Persist and reuse recent searches in search field

### DIFF
--- a/CityWeather/CityWeather/UI/Screens/Search/SearchView.swift
+++ b/CityWeather/CityWeather/UI/Screens/Search/SearchView.swift
@@ -11,6 +11,7 @@ import CWModels
 struct SearchView: View {
   @StateObject private var viewModel: SearchViewViewModel
   @State private var searchText = ""
+  @FocusState private var isSearchFocused: Bool
 
   init(viewModel: SearchViewViewModel = SearchViewViewModel()) {
     _viewModel = StateObject(wrappedValue: viewModel)
@@ -19,7 +20,7 @@ struct SearchView: View {
   var body: some View {
     NavigationStack {
       VStack {
-        SearchBar(searchText: $searchText) { text in
+        SearchBar(searchText: $searchText, isFocused: $isSearchFocused) { text in
           viewModel.getCityByName(cityName: text)
         }
         content
@@ -33,10 +34,15 @@ struct SearchView: View {
   
   @ViewBuilder
   private var content: some View {
-    switch viewModel.loadingState {
-    case .loading: loadingView
-    case .success: cityListView
-    case .none, .failed: Spacer()
+    if isSearchFocused {
+      cityListView
+    }
+    else {
+      switch viewModel.loadingState {
+      case .loading: loadingView
+      case .success: cityListView
+      case .none, .failed: Spacer()
+      }
     }
   }
   

--- a/CityWeather/CityWeather/UI/Screens/Search/SearchView.swift
+++ b/CityWeather/CityWeather/UI/Screens/Search/SearchView.swift
@@ -10,6 +10,7 @@ import CWModels
 
 struct SearchView: View {
   @StateObject private var viewModel: SearchViewViewModel
+  @State private var searchText = ""
 
   init(viewModel: SearchViewViewModel = SearchViewViewModel()) {
     _viewModel = StateObject(wrappedValue: viewModel)
@@ -18,7 +19,7 @@ struct SearchView: View {
   var body: some View {
     NavigationStack {
       VStack {
-        SearchBar { text in
+        SearchBar(searchText: $searchText) { text in
           viewModel.getCityByName(cityName: text)
         }
         content
@@ -54,6 +55,10 @@ struct SearchView: View {
         .fontWeight(.bold)
       ForEach(viewModel.history, id: \.self) { city in
         NavigationLink(city.name, value: city)
+          .simultaneousGesture(TapGesture().onEnded {
+            searchText = city.name
+            viewModel.getCityByName(cityName: city.name)
+          })
           .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
               viewModel.deleteHistory(city: city)

--- a/CityWeather/CityWeather/UI/Screens/Search/SearchViewViewModel.swift
+++ b/CityWeather/CityWeather/UI/Screens/Search/SearchViewViewModel.swift
@@ -18,11 +18,18 @@ extension ServiceManager: CitySearching {}
 
 final class SearchViewViewModel: ObservableObject {
   private let citySearcher: CitySearching
+  private let userDefaults: UserDefaults
+  private let historyKey = "recentSearchHistory"
   @Published var loadingState: LoadingState = .none
-  @Published var history: [City] = []
+  @Published var history: [City] = [] {
+    didSet { persistHistory() }
+  }
 
-  init(citySearcher: CitySearching = ServiceManager.shared) {
+  init(citySearcher: CitySearching = ServiceManager.shared,
+       userDefaults: UserDefaults = .standard) {
     self.citySearcher = citySearcher
+    self.userDefaults = userDefaults
+    loadHistory()
   }
 
   func getCityByName(cityName: String) {
@@ -47,7 +54,7 @@ final class SearchViewViewModel: ObservableObject {
   func deleteHistory(city: City) {
     history.removeAll(where: { $0 == city })
   }
-  
+
   private func shouldAddHistory(city: City) {
     if history.contains(city) {
       history.removeAll(where: { $0 == city })
@@ -56,5 +63,16 @@ final class SearchViewViewModel: ObservableObject {
     else {
       history.insert(city, at: 0)
     }
+  }
+
+  private func persistHistory() {
+    guard let encoded = try? JSONEncoder().encode(history) else { return }
+    userDefaults.set(encoded, forKey: historyKey)
+  }
+
+  private func loadHistory() {
+    guard let data = userDefaults.data(forKey: historyKey) else { return }
+    guard let savedHistory = try? JSONDecoder().decode([City].self, from: data) else { return }
+    history = savedHistory
   }
 }

--- a/CityWeather/CityWeather/UI/SearchBar/SearchBar.swift
+++ b/CityWeather/CityWeather/UI/SearchBar/SearchBar.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct SearchBar: View {
-  @State private var searchText = ""
+  @Binding var searchText: String
   var onSearchButtonClicked: (String) -> Void
   
   var body: some View {
     HStack {
       TextField("Search...", text: $searchText, onCommit: {
-        onSearchButtonClicked(standardizeSearchText(searchText))
+        let standardizedText = standardizeSearchText(searchText)
+        searchText = standardizedText
+        onSearchButtonClicked(standardizedText)
       })
       .padding(8)
       .background(Color(.systemGray6))

--- a/CityWeather/CityWeather/UI/SearchBar/SearchBar.swift
+++ b/CityWeather/CityWeather/UI/SearchBar/SearchBar.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 struct SearchBar: View {
   @Binding var searchText: String
+  @FocusState.Binding var isFocused: Bool
   var onSearchButtonClicked: (String) -> Void
-  
+
   var body: some View {
     HStack {
       TextField("Search...", text: $searchText, onCommit: {
@@ -19,6 +20,7 @@ struct SearchBar: View {
         onSearchButtonClicked(standardizedText)
       })
       .padding(8)
+      .focused($isFocused)
       .background(Color(.systemGray6))
       .cornerRadius(8)
       .padding(.horizontal)


### PR DESCRIPTION
## Summary
- add a bound search text field so the search bar can be updated externally
- update the search screen to reuse recent searches by populating the search field and re-triggering a lookup when tapped
- persist recent search history across app launches via UserDefaults so previous keywords remain available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e4ef16c8832a8f8d5d066ca22d4e)